### PR TITLE
Relax version constraint on nokogiri

### DIFF
--- a/views.gemspec
+++ b/views.gemspec
@@ -32,12 +32,12 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.13'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.2'
   spec.add_development_dependency 'savon', '~> 2.0'
-  spec.add_development_dependency 'nokogiri', '1.10.4'
-  
+  spec.add_development_dependency 'nokogiri', '~> 1.10.4'
+
   spec.add_runtime_dependency 'savon', '~> 2.0'
-  spec.add_runtime_dependency 'nokogiri', '1.10.4'
+  spec.add_runtime_dependency 'nokogiri', '~> 1.10.4'
 end


### PR DESCRIPTION
By loosening the version lock we can bump the nokogiri version in nightingale as well.